### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -21,7 +21,7 @@ jobs:
         steps:
             -   uses: actions/checkout@master
             -   name: Publish to Registry
-                uses: elgohr/Publish-Docker-Github-Action@master
+                uses: elgohr/Publish-Docker-Github-Action@v5
                 with:
                     name: csredrat/topalias
                     username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore